### PR TITLE
Refatoramento & Retestes

### DIFF
--- a/lib/skeleton/config/scripts/android/ci_android_main.sh
+++ b/lib/skeleton/config/scripts/android/ci_android_main.sh
@@ -1,0 +1,44 @@
+export reports_path="$WORKSPACE/reports-cal"
+
+# Input variables:
+# $1 - The parameters of what test to execute. Example "- @dev" or "" for nothing
+
+#bash $WORKSPACE/config/scripts/android/start_emulators.sh
+
+bash $WORKSPACE/config/scripts/android/run_tests_all_devices.sh $WORKSPACE/app/build/outputs/apk/app-gebsaprev-homolog.apk "" $1
+
+# Looking inside the html tests results to see if any one of the scenarios failed and exporting an ENV variable with this result.
+source $WORKSPACE/config/scripts/check_if_tests_failed.sh
+
+# Setting the email variable that depends on the test result status
+if [ $TESTS_RESULT == "Ok" ]
+then
+  export STATUS_TITLE="Sucesso"
+  export STATUS="\<font\ color\=\"green\"\>PASSARAM\<\/font\>"
+else
+	if [ $TESTS_RESULT == "Ok_with_issues" ]
+	then
+		export STATUS_TITLE="Sucesso"
+ 		export STATUS="\<font\ color\=\"green\"\>PASSARAM com ressalvas\<\/font\>"
+ 	else
+		export STATUS_TITLE="Erro"
+		export STATUS="\<font\ color\=\"red\"\>QUEBRARAM\<\/font\>"
+	fi
+fi
+echo "o status do TESTS_RESULT é $TESTS_RESULT\n"
+
+# Replacing the email template variables
+sed -i.bak "s/_STATUS_TITLE_/${STATUS_TITLE}/g" ${WORKSPACE}/config/email/template.html
+sed -i.bak "s/_STATUS_/${STATUS}/g" ${WORKSPACE}/config/email/template.html
+sed -i.bak "s/_JOB_NAME_/${JOB_NAME}/g" ${WORKSPACE}/config/email/template.html
+sed -i.bak "s/_BUILD_NUMBER_/${BUILD_NUMBER}/g" ${WORKSPACE}/config/email/template.html
+sed -i.bak "s/_OS_/Android/g" ${WORKSPACE}/config/email/template.html
+
+echo "Enviando e-mail\n"
+
+# Sending the email (descomentar para quando for rodar em homolog/prod)
+mutt -e 'set from="MacCI Jenkins <macci@concretesolutions.com.br>"' -e "set content_type=text/html" -s "Itaú Soluções - Participante Mobile - Testes BDD Android - ${STATUS_TITLE}" itausolucoes-mobile@googlegroups.com < ${WORKSPACE}/config/email/template.html
+
+
+# Breaking the build if there was any error on the test result htmls.
+bash $WORKSPACE/config/scripts/break_build_if_failed.sh

--- a/lib/skeleton/config/scripts/android/ci_android_main.sh
+++ b/lib/skeleton/config/scripts/android/ci_android_main.sh
@@ -37,7 +37,7 @@ sed -i.bak "s/_OS_/Android/g" ${WORKSPACE}/config/email/template.html
 echo "Enviando e-mail\n"
 
 # Sending the email (descomentar para quando for rodar em homolog/prod)
-mutt -e 'set from="MacCI Jenkins <macci@concretesolutions.com.br>"' -e "set content_type=text/html" -s "Itaú Soluções - Participante Mobile - Testes BDD Android - ${STATUS_TITLE}" itausolucoes-mobile@googlegroups.com < ${WORKSPACE}/config/email/template.html
+mutt -e 'set from="MacCI Jenkins <macci@concretesolutions.com.br>"' -e "set content_type=text/html" -s "Itaú Soluções - Participante Mobile - Testes BDD Android - ${STATUS_TITLE}" setar_aqui@setar_aqui.com < ${WORKSPACE}/config/email/template.html
 
 
 # Breaking the build if there was any error on the test result htmls.

--- a/lib/skeleton/config/scripts/android/ci_android_main.sh
+++ b/lib/skeleton/config/scripts/android/ci_android_main.sh
@@ -37,7 +37,7 @@ sed -i.bak "s/_OS_/Android/g" ${WORKSPACE}/config/email/template.html
 echo "Enviando e-mail\n"
 
 # Sending the email (descomentar para quando for rodar em homolog/prod)
-mutt -e 'set from="MacCI Jenkins <macci@concretesolutions.com.br>"' -e "set content_type=text/html" -s "Itaú Soluções - Participante Mobile - Testes BDD Android - ${STATUS_TITLE}" setar_aqui@setar_aqui.com < ${WORKSPACE}/config/email/template.html
+mutt -e 'set from="MacCI Jenkins <macci@concretesolutions.com.br>"' -e "set content_type=text/html" -s "Assunto e o status:  ${STATUS_TITLE}" setar_aqui@setar_aqui.com < ${WORKSPACE}/config/email/template.html
 
 
 # Breaking the build if there was any error on the test result htmls.

--- a/lib/skeleton/config/scripts/android/run_tests_all_devices.sh
+++ b/lib/skeleton/config/scripts/android/run_tests_all_devices.sh
@@ -5,7 +5,7 @@
 #
 # $1 -> parameter with the name of the apk
 # $2 -> parameter to indicates the tapume to run. Can be null and can have other 2 values: must or should
-# $3 -> parameter with tests specs. For exxameple, use  "feature/<feature_name>" to select an specific feature file; use "" for everything
+# $3 -> parameter with tests specs. For exxameple, put "feature/<feature_name>" to select an specific feature file; put "" for everything
 
 ## CODE BEGIN  #############################################################
 [ $# -lt 1 ] && echo "Wrong number of parameters." && exit 1
@@ -41,7 +41,7 @@ do
     reports_url="$reports_url""$JOB_URL""ws/reports-cal/$device/report_1/reports.html "
     reports_folders="$reports_folders""$JOB_URL""ws/reports-cal/$device "
   else 
-    #para uso em ambiente de máquina local...
+    #for use on local developer machines...
     reports_url="$reports_url$WORKSPACE/reports-cal/$device/report_1/reports.html "
     reports_folders="$reports_folders$WORKSPACE/reports-cal/$device "
   fi
@@ -59,8 +59,8 @@ for device in $(adb devices | grep "device$" | cut -f 1)
 do
   cd $WORKSPACE
   # Creates the reports folder
-  mkdir -p "$reports_path"/"$device"/report_1/report_1/
-  mkdir -p "$reports_path"/"$device"/report_1/report_2/
+  mkdir -p "$reports_path"/"$device"/report_1/
+  mkdir -p "$reports_path"/"$device"/report_2/
   port=$((port+1)) #increase port
   {
 
@@ -70,18 +70,18 @@ do
       then
         
         echo Tentativa de destravar a tela de $device 
-        #travando, com redundancia
+        #locking twice, just to guarantee (ensure they always start equally)
         adb -s $device shell input keyevent 26
         adb -s $device shell input keyevent 26
 
-        #destravando
+        #unlocking
         wait 2
         adb -s $device shell input keyevent 82
         adb -s $device shell input keyevent 82
 
       fi
 
-      #dando Home uma vez...
+      #press Home once...
       adb -s $device shell input keyevent 3
 
      
@@ -97,14 +97,14 @@ do
       sed -i.bak 's|'"$reports_path"/"$device"/report_1/'||g' "$reports_path"/"$device"/report_1/reports.html
       sed -i.bak 's|'"$reports_path"/"$device"/report_2/'||g' "$reports_path"/"$device"/report_2/reports.html
 
-      #dando Home uma vez...
+      #pressing home once... (to ensure everything else goes to background)
       adb -s $device shell input keyevent 3
   }&
 
 done
 wait
 
-#verifico se tem relatório de retestes e se eles tem falhas e adiciono à lista de relatorios para o relatório consolidado
+#checking if there's any retest report and if they contain errors. If so they are referenced on the summary report...
 cd "$WORKSPACE/reports-cal"
 
 for aFolder in *
@@ -113,7 +113,7 @@ do
   
   echo  "Vamos buscar retestes em $aFolder"
   if [ -a "$aFolder/report_2/reports.html" ]  
-  then     #se contem arquivo reports2.html (estando ele com coisas certas ou não)
+  then     
       echo "Achou-se reports.html em $aFolder/report2/reports.html depois de iterar na pasta de reports do device ou emulator $device \n"
 
       reports_url="$reports_url$aFolder/report_2/reports.html "
@@ -121,7 +121,7 @@ do
 done
 
 cd $WORKSPACE
-#gera relatorio consolidado
+#making the summary report
 echo "A sequencia de url ficou como: \n $reports_url"
 ./config/scripts/gera_reports_html.sh $reports_url > reports-cal/reports.html
 

--- a/lib/skeleton/config/scripts/android/run_tests_all_devices.sh
+++ b/lib/skeleton/config/scripts/android/run_tests_all_devices.sh
@@ -5,9 +5,15 @@
 #
 # $1 -> parameter with the name of the apk
 # $2 -> parameter to indicates the tapume to run. Can be null and can have other 2 values: must or should
+# $3 -> parameter with tests specs. For exxameple, use  "feature/<feature_name>" to select an specific feature file; use "" for everything
 
 ## CODE BEGIN  #############################################################
 [ $# -lt 1 ] && echo "Wrong number of parameters." && exit 1
+
+#setting which enviroment we are dealing wiff (CI or local)
+enviroment='CI'
+
+
 
 # Counting the number of lines returned from the command adb devices
 # This command will return at least 2 as result, because of one header line and one empty line at end
@@ -21,21 +27,103 @@ echo Inicio da execução: $(date)
 reports_path="$WORKSPACE/reports-cal"
 mkdir $reports_path
 
+# Setting reports_url
+reports_url=""
+
+# Setting reports_folders
+reports_folders=""
+
+for device in $(adb devices | grep "device$" | cut -f 1)
+do
+
+  if [ $ambiente == "CI" ]
+  then
+    reports_url="$reports_url""$JOB_URL""ws/reports-cal/$device/report_1/reports.html "
+    reports_folders="$reports_folders""$JOB_URL""ws/reports-cal/$device "
+  else 
+    #para uso em ambiente de máquina local...
+    reports_url="$reports_url$WORKSPACE/reports-cal/$device/report_1/reports.html "
+    reports_folders="$reports_folders$WORKSPACE/reports-cal/$device "
+  fi
+done
+
+
+# Starting port - can be a random port ( choosen by fair dice roll )
+port=34800 
+
+# Resigning app
+calabash-android resign "$1"
+
+
 for device in $(adb devices | grep "device$" | cut -f 1)
 do
   cd $WORKSPACE
   # Creates the reports folder
-  mkdir "$reports_path"/"$device"
-
+  mkdir -p "$reports_path"/"$device"/report_1/report_1/
+  mkdir -p "$reports_path"/"$device"/report_1/report_2/
+  port=$((port+1)) #increase port
   {
-      ADB_DEVICE_ARG=$device SCREENSHOT_PATH="$reports_path"/"$device"/ calabash-android run $1 -p android -f 'Calabash::Formatters::Html' -o "$reports_path"/"$device"/reports.html -f junit -o "$reports_path"/"$device"
+
+
+     is_emulator=$(echo $device | grep "emulator")
+      if test -n "$is_emulator"
+      then
+        
+        echo Tentativa de destravar a tela de $device 
+        #travando, com redundancia
+        adb -s $device shell input keyevent 26
+        adb -s $device shell input keyevent 26
+
+        #destravando
+        wait 2
+        adb -s $device shell input keyevent 82
+        adb -s $device shell input keyevent 82
+
+      fi
+
+      #dando Home uma vez...
+      adb -s $device shell input keyevent 3
+
+     
+      # #iniciando Calabash
+
+      echo "Inicializando Calabash para $device na porta $port "
+
+      echo "Usando terceiro parametro $3"
+
+      ADB_DEVICE_ARG=$device SCREENSHOT_PATH="$reports_path"/"$device"/report_1/ calabash-android run $1 -p android "$3" --format rerun --out tmp/rerun_"$device".txt -f 'Calabash::Formatters::Html' -o "$reports_path"/"$device"/report_1/reports.html -f junit -o "$reports_path"/"$device"/report_1 || (echo "Retestando para $device: " && ADB_DEVICE_ARG=$device SCREENSHOT_PATH="$reports_path"/"$device"/report_2/ calabash-android run $1 -p android @tmp/rerun_"$device".txt -f 'Calabash::Formatters::Html' -o "$reports_path"/"$device"/report_2/reports.html -f junit -o "$reports_path"/"$device"/report_2 ) 
       # Calabash has a problem with images relative path, the command above will replace all the images path on the
       # html report file to be a relative path
-      sed -i.bak 's|'"$reports_path"/"$device"/'||g' "$reports_path"/"$device"/reports.html
+      sed -i.bak 's|'"$reports_path"/"$device"/report_1/'||g' "$reports_path"/"$device"/report_1/reports.html
+      sed -i.bak 's|'"$reports_path"/"$device"/report_2/'||g' "$reports_path"/"$device"/report_2/reports.html
+
+      #dando Home uma vez...
+      adb -s $device shell input keyevent 3
   }&
 
 done
 wait
+
+#verifico se tem relatório de retestes e se eles tem falhas e adiciono à lista de relatorios para o relatório consolidado
+cd "$WORKSPACE/reports-cal"
+
+for aFolder in *
+do
+
+  
+  echo  "Vamos buscar retestes em $aFolder"
+  if [ -a "$aFolder/report_2/reports.html" ]  
+  then     #se contem arquivo reports2.html (estando ele com coisas certas ou não)
+      echo "Achou-se reports.html em $aFolder/report2/reports.html depois de iterar na pasta de reports do device ou emulator $device \n"
+
+      reports_url="$reports_url$aFolder/report_2/reports.html "
+  fi  
+done
+
+cd $WORKSPACE
+#gera relatorio consolidado
+echo "A sequencia de url ficou como: \n $reports_url"
+./config/scripts/gera_reports_html.sh $reports_url > reports-cal/reports.html
 
 echo Fim da execução: $(date)
 ## CODE END  #############################################################

--- a/lib/skeleton/config/scripts/check_if_tests_failed.sh
+++ b/lib/skeleton/config/scripts/check_if_tests_failed.sh
@@ -2,10 +2,17 @@
 cd "$WORKSPACE/reports-cal"
 
 export TESTS_RESULT="Ok"
+
 for folder in *
 do
-    if egrep '[0-9]+ failed' "$folder/reports.html"
-    then
-	export TESTS_RESULT="Failed"
-    fi
+   if egrep '[0-9]+ failed' "$folder/report_1/reports.html"
+   then
+   		if egrep '[0-9]+ failed' "$folder/report_2/reports.html"
+   		then
+			export TESTS_RESULT="Failed"
+		else
+			export TESTS_RESULT="Ok_with_issues"  # Passou na bateria de testes. Está OK, mas com ressalvas - para uso do QA...
+   			echo "The test is $TESTS_RESULT"
+   		fi
+   fi
 done

--- a/lib/skeleton/config/scripts/gera_reports_html.sh
+++ b/lib/skeleton/config/scripts/gera_reports_html.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# make_page - A script to produce an HTML file
+
+
+relatorios_1=""
+relatorios_2=""
+
+for report_file in $*
+do
+
+    if [[ $report_file == *"report_1/reports.html"* ]]
+    then
+            relatorios_1="$relatorios_1 <p><a href='$report_file'>$report_file</a></p>"
+
+    fi
+
+    if [[ $report_file == *"report_2/reports.html"* ]]
+    then
+            relatorios_2="$relatorios_2 <p><a href='$report_file'>$report_file</a></p>"
+
+    fi
+done
+
+if [[ $relatorios_2 == "" ]]
+
+then
+cat <<- _EOF_
+    <HTML>
+    <HEAD>
+        <TITLE>
+        My System Information
+        </TITLE>
+    </HEAD>
+
+    <BODY>
+    <H1>Cucumber Report</H1>
+    $relatorios_1
+    </BODY>
+    </HTML>
+_EOF_
+
+else
+
+cat <<- _EOF_
+    <HTML>
+    <HEAD>
+        <TITLE>
+        My System Information
+        </TITLE>
+    </HEAD>
+
+    <BODY>
+    <H1>My Cucumber Report</H1>
+    <H2>1st report with unexpected errors </H2>
+    $relatorios_1
+    <H2>2nd report with only unexpected errors retested </H2>
+    $relatorios_2
+    </BODY>
+    </HTML>
+_EOF_
+fi

--- a/lib/skeleton/config/scripts/ios/build_app.rb
+++ b/lib/skeleton/config/scripts/ios/build_app.rb
@@ -44,7 +44,7 @@ FileUtils.mkdir_p export_path
 
 # Choosing the SDK for device or simulator
 sdk = ''
-if ARGV[1] == 'device'
+if (ARGV[1] == 'devices' || ARGV[1] == 'device') 
   sdk = 'iphoneos'
 else
   sdk = 'iphonesimulator'

--- a/lib/skeleton/config/scripts/ios/ci_ios_main.sh
+++ b/lib/skeleton/config/scripts/ios/ci_ios_main.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Input variables:
+# $1 - The parameters of what test to execute. Example "- @dev" or "" for nothing
+
+ambiente="CI"
+
+cd $WORKSPACE
+
+if [ $ambiente == "CI" ]
+then
+	export IOS_WORKSPACE=$WORKSPACE/../isp-participantemobile-ios-master
+	ruby ./config/scripts/ios/build_app.rb jenkins simulator
+	ruby ./config/scripts/ios/build_app.rb jenkins devices
+fi
+export LANG=en_US.UTF-8
+export LANGUAGE=en_US:en
+
+
+#sh $WORKSPACE/config/scripts/ios/run_tests_all_devices.sh ./app/build/ios/simulator/Gebsa-cal.app ./app/build/ios/simulator/Gebsa-cal.app
+sh $WORKSPACE/config/scripts/ios/run_tests_all_devices.sh null null "$1"
+
+# Looking inside the html tests results to see if any one of the scenarios failed and exporting an ENV variable with this result.
+source ./config/scripts/check_if_tests_failed.sh
+
+# Setting the email variable that depends on the test result status
+if [ $TESTS_RESULT == "Ok" ]
+then
+  export STATUS_TITLE="Sucesso"
+  export STATUS="\<font\ color\=\"green\"\>PASSARAM\<\/font\>"
+else
+	if [ $TESTS_RESULT == "Ok_with_issues" ]
+	then
+		export STATUS_TITLE="Sucesso"
+ 		export STATUS="\<font\ color\=\"green\"\>PASSARAM com ressalvas\<\/font\>"
+ 	else
+		export STATUS_TITLE="Erro"
+		export STATUS="\<font\ color\=\"red\"\>QUEBRARAM\<\/font\>"
+	fi
+fi
+echo "o status do TESTS_RESULT é $TESTS_RESULT\n"
+
+# Replacing the email template variables
+cd ${WORKSPACE}
+sed -i.bak "s/_STATUS_TITLE_/${STATUS_TITLE}/g" ./config/email/template.html
+sed -i.bak "s/_STATUS_/${STATUS}/g" ./config/email/template.html
+sed -i.bak "s/_JOB_NAME_/${JOB_NAME}/g" ./config/email/template.html
+sed -i.bak "s/_BUILD_NUMBER_/${BUILD_NUMBER}/g" ./config/email/template.html
+sed -i.bak "s/_OS_/Android/g" ./config/email/template.html
+
+
+if [ $ambiente == "CI" ] 
+then
+# Sending the email
+	# mutt -e 'set from="MacCI Jenkins <macci@concretesolutions.com.br>"' -e "set content_type=text/html" -s "Itaú Soluções - Participante Mobile - Testes BDD iOS - ${STATUS_TITLE}" itausolucoes-mobile@googlegroups.com < ./config/email/template.html
+else
+	mutt -e 'set from="MacCI Jenkins <macci@concretesolutions.com.br>"' -e "set content_type=text/html" -s "Assunto e o status:  ${STATUS_TITLE}" setar_aqui@setar_aqui.com < ${WORKSPACE}/config/email/template.html
+fi
+# Breaking the build if there was any error on the test result htmls.
+bash ./config/scripts/break_build_if_failed.sh

--- a/lib/skeleton/config/scripts/ios/devices_local.txt
+++ b/lib/skeleton/config/scripts/ios/devices_local.txt
@@ -1,0 +1,4 @@
+# <DEVICE_TARGET (UUID)> | <DEVICE_ENDPOINT (IP)> | <DEVICE_NAME> | <DEVICE_TYPE> (Simulator or Device)
+000...000 | http://localhost:37265 | Device0 | Simulator
+111...111 | http://1.1.1.1:37265 | Device1 | Device
+# EOF - Never erase this comment or the script will have problems to read this file

--- a/lib/skeleton/config/scripts/ios/run_tests_all_devices.sh
+++ b/lib/skeleton/config/scripts/ios/run_tests_all_devices.sh
@@ -5,10 +5,15 @@
 #
 # $1 -> parameter with the path of the .app bundle for simulators
 # $2 -> parameter with the path of the .app bundle for devices
+# $3 -> parameter with the tests to be executed. For example: put "-t @test" or just put "" for everything
+
 
 ## CODE BEGIN  #############################################################
 
 echo Start: $(date)
+
+#sets the enviroment (CI or local)
+ambiente="CI"
 
 # Exits if the app path was not informed
 [ $# -lt 2 ] && echo "Wrong number of parameters." && exit 1
@@ -27,15 +32,79 @@ cd "$original_path"
 cd "$2"
 DEVICE_APP_PATH="$(pwd)"
 
+# showing the versions of calabash-ios in the machine and in the app to be tested:
+echo "A versão do calabash nesta máquina é:"
+calabash-ios version
+echo "A versão do ios-deploy é"
+ios-deploy -V
+echo "Listando todos os simulators disponíveis nesta máquina:"
+xcrun simctl list
 cd $WORKSPACE # All tests should run from the root folder of the tests project
+# Setting reports_url and his tem file for use in pipe loops (while)
+reports_url=""
+reports_url_temp=/tmp/reports_url_temp
 
-cat config/scripts/ios/devices.txt |  ## Reading the devices.txt file
+# Setting reports_folders and his tem file for use in pipe loops (while)
+reports_folders=""
+reports_folders_temp=/tmp/reports_folders_temp
+
+# setting where de list of devices or simulators come from
+devices=""
+if [ $ambiente == "CI" ]
+then
+    devices="devices.txt"
+else 
+    devices="devices_local.txt"
+fi
+echo "A variável devices contem $devices"
+echo "O ambiente é $ambiente"
+echo "Associando um url para este dipositivo ou simulador \n"
+cat config/scripts/ios/"$devices" |  ## Reading the devices.txt file
+
+grep -v "#" | ## Removing the command lines
+tr -d " " | ## Trimming all the spaces
+while IFS='|' read UUID IP NAME TYPE
+do
+    #Linking an url for this device or simulator
+
+    # reports_url="$reports_url$JOB_URL/ws/reports-cal/$NAME/reports.html "
+    # reports_folders="$reports_folders$JOB_URL/ws/reports-cal/$NAME "
+    mkdir -p "$reports_path"/"$NAME"/report_1/
+    mkdir -p "$reports_path"/"$NAME"/report_2/
+
+    if [ $ambiente == "CI" ]
+    then
+        echo motando resports_url em ambente $ambiente 
+        reports_url="$reports_url""$JOB_URL""ws/reports-cal/$NAME/report_1/reports.html \t"
+        reports_folders="$reports_folders""$JOB_URL""ws/reports-cal/$NAME \t"
+        echo -e $reports_url > $reports_url_temp
+        echo -e $reports_folders > $reports_folders_temp
+        echo e ficou $reports_url
+    else
+        echo motando resports_url em ambente $ambiente 
+        reports_url="$reports_url$WORKSPACE/reports-cal/$NAME/report_1/reports.html \t" 
+        reports_folders="$reports_folders$WORKSPACE/reports-cal/$NAME \t"
+        echo -e $reports_url > $reports_url_temp
+        echo -e $reports_folders > $reports_folders_temp
+        echo e ficou $reports_url
+    fi 
+done
+
+reports_url=$(cat $reports_url_temp)
+reports_folders=$(cat $reports_folders_temp)
+echo depois de associar, o reports_url ficou assim: $reports_url
+
+# All tests should run from the root folder of the tests project
+cd $WORKSPACE 
+
+echo "Entrando na rotina de testes \n"
+cat config/scripts/ios/"$devices" |  ## Reading the devices.txt file
+
 grep -v "#" | ## Removing the command lines
 tr -d " " | ## Trimming all the spaces
 while IFS='|' read UUID IP NAME TYPE ## Defining pipe as the separator char and reading the three variable fields
 do 
-    # Creating the report folder for this device or simulator
-    mkdir "$reports_path"/"$NAME"
+    
 
     if [ $TYPE == "Simulator" ]
     then
@@ -45,12 +114,39 @@ do
     fi
     
     # Executing calabash for the device or simulator
-    APP_BUNDLE_PATH="$APP_PATH" DEVICE_TARGET="$UUID" DEVICE_ENDPOINT="$IP" SCREENSHOT_PATH="$reports_path"/"$NAME"/ cucumber -p ios -f 'Calabash::Formatters::Html' -o "$reports_path"/"$NAME/reports.html" -f junit -o "$reports_path"/"$NAME"
+    echo nome: $NAME 
+    echo path: $APP_PATH 
+    echo executando para "$3"
+
+    APP_BUNDLE_PATH="$APP_PATH" DEVICE_TARGET="$UUID" DEVICE_ENDPOINT="$IP" SCREENSHOT_PATH="$reports_path"/"$NAME"/report_1/ cucumber -p ios $3 --format rerun --out tmp/rerun_"$NAME".txt -f 'Calabash::Formatters::Html' -o "$reports_path"/"$NAME"/report_1/reports.html -f junit -o "$reports_path"/"$NAME"/report_1 || (echo "Retestando para $NAME: " &&  APP_BUNDLE_PATH="$APP_PATH" DEVICE_TARGET="$UUID" DEVICE_ENDPOINT="$IP" SCREENSHOT_PATH="$reports_path"/"$NAME"/report_2/ cucumber -p ios  @tmp/rerun_"$NAME".txt -f 'Calabash::Formatters::Html' -o "$reports_path"/"$NAME"/report_2/reports.html -f junit -o "$reports_path"/"$NAME"/report_2)
 
     # Calabash has a problem with images relative path, the command above will replace all the images path on the
     # html report file to be a relative path
-    sed -i.bak 's|'"$reports_path"/"$NAME"/'||g' "$reports_path"/"$NAME"/reports.html
+    sed -i.bak 's|'"$reports_path"/"$NAME"/report_1/'||g' "$reports_path"/"$NAME"/report_1/reports.html
+    sed -i.bak 's|'"$reports_path"/"$NAME"/report_2/'||g' "$reports_path"/"$NAME"/report_2/reports.html
+
+    echo "Terminada execução para $NAME"   
+
 done
+
+#checking if there's any retest report and if they contain errors. If so they are referenced on the summary report...
+cd "$WORKSPACE/reports-cal"
+for aFolder in *
+do
+  
+  echo  "Vamos buscar retestes em $aFolder"
+  if [ -a "$aFolder/report_2/reports.html" ]  
+  then     
+      echo "Achou-se reports.html em $aFolder/report_2/reports.html depois de iterar na pasta de reports do device ou emulator $device \n"
+      reports_url="$reports_url$aFolder/report_2/reports.html "
+  fi  
+done        
+
+cd $WORKSPACE 
+      
+        #making the summary report
+        echo O reports_url é $reports_url       
+        ./config/scripts/gera_reports_html.sh $reports_url > reports-cal/reports.html
 
 echo End: $(date)
 echo 'Bye!'


### PR DESCRIPTION
Adicionei arquivos ci_android_main.sh e ci_ios_main.sh que passa a deixar no repositório dos desenvolvedores os principais comandos utilizados em CI.
Exibe relatório consolidado para múltiplos devices.
Modifiquei o "run_test_all_devices.sh" para suportarem a possibilidade de retestes. 
