### PR TITLE
Criação dos comandos RUN e BUILD

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in cs-bdd.gemspec
 gemspec
-
-gem 'thor'
-gem 'i18n'
-gem 'json'
-gem 'gherkin', '~> 2.12.2'
-gem 'highline'
-gem 'colorize'

--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,6 @@ gemspec
 gem 'thor'
 gem 'i18n'
 gem 'json'
-gem 'gherkin'
+gem 'gherkin', '~> 2.12.2'
+gem 'highline'
+gem 'colorize'

--- a/bin/cs-bdd
+++ b/bin/cs-bdd
@@ -7,9 +7,125 @@ require 'gherkin' # Used here as a translation source
 require 'json'
 require 'yaml'
 require 'highline'
+require 'colorize'
 
 require File.join(File.dirname(__FILE__), 'cs-bdd-helpers')
 require_relative '../lib/cs/bdd/version'
+
+module CS
+  module BDD
+    # Definition of all gem generators
+    class Generate < Thor
+      include Thor::Actions
+
+      desc 'feature [RESOURCE_NAME]', 'Generates an OS independent feature'
+      option :lang,
+             banner: 'any of the gherkin supported languages',
+             default: :en
+      def feature(name)
+        I18n.config.default_locale = options[:lang]
+        in_root_project_folder?
+
+        create_feature_file(name)
+        create_steps_file name
+        create_screen_file name, 'Android'
+        create_screen_file name, 'IOS'
+      end
+
+      desc 'aFeature [RESOURCE_NAME]', 'Generates an Android dependent feature'
+      option :lang,
+             banner: 'any of the gherkin supported languages',
+             default: :en
+      def aFeature(name)
+        I18n.config.default_locale = options[:lang]
+        in_root_project_folder?
+
+        create_feature_file name, 'Android'
+        create_steps_file name, 'Android'
+        create_screen_file name, 'Android'
+      end
+
+      desc 'iFeature [RESOURCE_NAME]', 'Generates an iOS dependent feature'
+      option :lang,
+             banner: 'any of the gherkin supported languages',
+             default: :en
+      def iFeature(name)
+        I18n.config.default_locale = options[:lang]
+        in_root_project_folder?
+
+        create_feature_file name, 'IOS'
+        create_steps_file name, 'IOS'
+        create_screen_file name, 'IOS'
+      end
+
+      desc 'step [RESOURCE_NAME]', 'Generates an OS independent step'
+      option :lang,
+             banner: 'any of the gherkin supported languages',
+             default: :en
+      def step(name)
+        I18n.config.default_locale = options[:lang]
+        in_root_project_folder?
+        create_steps_file name
+      end
+
+      desc 'aStep [RESOURCE_NAME]', 'Generates an Android dependent step'
+      option :lang,
+             banner: 'any of the gherkin supported languages',
+             default: :en
+      def aStep(name)
+        I18n.config.default_locale = options[:lang]
+        in_root_project_folder?
+        create_steps_file name, 'Android'
+      end
+
+      desc 'iStep [RESOURCE_NAME]', 'Generates an iOS dependent step'
+      option :lang,
+             banner: 'any of the gherkin supported languages',
+             default: :en
+      def iStep(name)
+        I18n.config.default_locale = options[:lang]
+        in_root_project_folder?
+        create_steps_file name, 'IOS'
+      end
+
+      desc 'screen [RESOURCE_NAME]',
+           'Generates the Android and iOS dependent screens'
+      option :lang,
+             banner: 'any of the gherkin supported languages',
+             default: :en
+      def screen(name)
+        I18n.config.default_locale = options[:lang]
+        in_root_project_folder?
+        create_screen_file name, 'Android'
+        create_screen_file name, 'IOS'
+      end
+
+      desc 'aScreen [RESOURCE_NAME]', 'Generates an Android dependent screen'
+      option :lang,
+             banner: 'any of the gherkin supported languages',
+             default: :en
+      def aScreen(name)
+        I18n.config.default_locale = options[:lang]
+        in_root_project_folder?
+        create_screen_file name, 'Android'
+      end
+
+      desc 'iScreen [RESOURCE_NAME]', 'Generates an iOS dependent screen'
+      option :lang,
+             banner: 'any of the gherkin supported languages',
+             default: :en
+      def iScreen(name)
+        I18n.config.default_locale = options[:lang]
+        in_root_project_folder?
+        create_screen_file name, 'IOS'
+      end
+
+      def self.source_root
+        File.join(File.dirname(__FILE__), '..', 'lib', 'templates')
+      end
+    end
+  end
+end
 
 module CS
   module BDD
@@ -29,20 +145,28 @@ module CS
               :banner => 'UUID'
               
       def ios(ip_address, profile = nil)
-        @cli.say("Loading...") if not in_root_project_folder?
+        @cli.say("Loading...") if !in_root_project_folder?
         
         profile ||= answer_profile
         options[:device] ||= answer_device_ios
+        target = uuid_get_type_target(options[:device])
         
         if !profile_exist? (profile)
           @cli.say("Profile inválid.")
           profile = answer_profile
         end
         configs = profile_configs[profile]
+        app_file = "#{configs["export_path"]}/#{target}/#{configs["scheme"]}.app"
         
-        command = "APP_BUNDLE_PATH='#{configs["export_path"]}/#{configs["scheme"]}.app'"
+        if !File.exist?(app_file)
+          @cli.say("\nNão foi possivel encontrar #{app_file}")
+          @cli.agree("\nDeseja fazer o build? [Y/n]")
+          invoke CS::BDD::Build, "ios", [profile], options
+        end
+        
+        command = "APP_BUNDLE_PATH='#{app_file}'"
         command += " PROJECT_DIR='#{project_folder_by_xcworkspace(configs["xcworkspace"])}'"
-        command += " DEVICET=#{options[:device]}"
+        command += " DEVICE_TARGET=#{options[:device]}"
         command += " DEVICE_ENDPOINT=http://#{ip_address}:#{options[:port]}"
         command += " bundle exec cucumber -p ios"
         command += " -t #{options[:tags]}" if options[:tags]
@@ -60,7 +184,7 @@ module CS
               :banner => 'TAG_EXPRESSION'
               
       def android(apk)
-        @cli.say("Loading...") if not in_root_project_folder?
+        @cli.say("Loading...") if !in_root_project_folder?
         command = "bundle exec calabash-android run '#{apk}' -p android"
         command += " -t #{options[:tags]}" if options[:tags]
         
@@ -88,22 +212,18 @@ module CS
               :banner => 'UUID'
               
       def ios(profile = nil)
-        @cli.say("Loading...") if #!in_root_project_folder?
+        @cli.say("Loading...") if !in_root_project_folder?
         
         profile ||= answer_profile
+        options[:device] ||= answer_device_ios
         
         if !profile_exist? (profile)
           @cli.say("Profile inválid.")
           profile = answer_profile
         end
-        configs = profile_configs[profile]
         
-        command = "APP_BUNDLE_PATH='#{configs["export_path"]}/#{configs["scheme"]}.app'"
-        command += " PROJECT_DIR='#{project_folder_by_xcworkspace(configs["xcworkspace"])}'"
-        command += " DEVICET=#{options[:device]}"
-        command += " DEVICE_ENDPOINT=http://#{ip_address}:#{options[:port]}"
-        command += " bundle exec cucumber -p ios"
-        command += " -t #{options[:tags]}" if options[:tags]
+        target = uuid_get_type_target(options[:device])
+        command = "ruby config/scripts/ios/build_app.rb #{profile} #{target}"
         
         @cli.say("Running command:\n")
         @cli.say("#{command.colorize(:blue)}\n\n")
@@ -138,6 +258,9 @@ module CS
       register CS::BDD::Runner, 'runner',
               'run [PLATFORM]',
               'Run tests in Android or iOS'
+      register CS::BDD::Build, 'build',
+              'build [PLATFORM]',
+              'Build project in Android or iOS'
 
       desc 'new PROJECT_NAME',
            'Generates the structure of a new project that uses '\
@@ -207,9 +330,6 @@ module CS
         ]
         I18n.backend.load_translations
         I18n.config.enforce_available_locales = true
-        
-        # Load Colorize
-        require 'colorize'
       end
     end
   end

--- a/bin/cs-bdd
+++ b/bin/cs-bdd
@@ -6,120 +6,115 @@ require 'i18n'
 require 'gherkin' # Used here as a translation source
 require 'json'
 require 'yaml'
+require 'highline'
 
 require File.join(File.dirname(__FILE__), 'cs-bdd-helpers')
 require_relative '../lib/cs/bdd/version'
 
 module CS
   module BDD
-    # Definition of all gem generators
-    class Generate < Thor
-      include Thor::Actions
-
-      desc 'feature [RESOURCE_NAME]', 'Generates an OS independent feature'
-      option :lang,
-             banner: 'any of the gherkin supported languages',
-             default: :en
-      def feature(name)
-        I18n.config.default_locale = options[:lang]
-        in_root_project_folder?
-
-        create_feature_file(name)
-        create_steps_file name
-        create_screen_file name, 'Android'
-        create_screen_file name, 'IOS'
+    class Runner < Thor
+      desc 'ios [IP_ADDRESS] [PROFILE]',
+           'Run tests in IOS.'
+      option  :tags,
+              :desc => 'Only execute the features or scenarios with tags matching TAG_EXPRESSION.',
+              :aliases => '-t',
+              :banner => 'TAG_EXPRESSION'
+      option  :port,
+              :desc => 'Port number to proxy connect.',
+              :banner => 'NUMBER',
+              :default => '37265'
+      option  :device,
+              :desc => 'UUID to device install app.',
+              :banner => 'UUID'
+              
+      def ios(ip_address, profile = nil)
+        @cli.say("Loading...") if not in_root_project_folder?
+        
+        profile ||= answer_profile
+        options[:device] ||= answer_device_ios
+        
+        if !profile_exist? (profile)
+          @cli.say("Profile inválid.")
+          profile = answer_profile
+        end
+        configs = profile_configs[profile]
+        
+        command = "APP_BUNDLE_PATH='#{configs["export_path"]}/#{configs["scheme"]}.app'"
+        command += " PROJECT_DIR='#{project_folder_by_xcworkspace(configs["xcworkspace"])}'"
+        command += " DEVICET=#{options[:device]}"
+        command += " DEVICE_ENDPOINT=http://#{ip_address}:#{options[:port]}"
+        command += " bundle exec cucumber -p ios"
+        command += " -t #{options[:tags]}" if options[:tags]
+        
+        @cli.say("\nRunning command:\n")
+        @cli.say("#{command.colorize(:light_blue)}\n\n")
+        exec(command)
       end
-
-      desc 'aFeature [RESOURCE_NAME]', 'Generates an Android dependent feature'
-      option :lang,
-             banner: 'any of the gherkin supported languages',
-             default: :en
-      def aFeature(name)
-        I18n.config.default_locale = options[:lang]
-        in_root_project_folder?
-
-        create_feature_file name, 'Android'
-        create_steps_file name, 'Android'
-        create_screen_file name, 'Android'
+      
+      desc 'android [APK]',
+           'Run tests in Android.'
+      option  :tags,
+              :desc => 'Only execute the features or scenarios with tags matching TAG_EXPRESSION.',
+              :aliases => '-t',
+              :banner => 'TAG_EXPRESSION'
+              
+      def android(apk)
+        @cli.say("Loading...") if not in_root_project_folder?
+        command = "bundle exec calabash-android run '#{apk}' -p android"
+        command += " -t #{options[:tags]}" if options[:tags]
+        
+        @cli.say("\nRunning command:\n")
+        @cli.say("#{command.colorize(:light_blue)}\n\n")
+        exec(command)
       end
-
-      desc 'iFeature [RESOURCE_NAME]', 'Generates an iOS dependent feature'
-      option :lang,
-             banner: 'any of the gherkin supported languages',
-             default: :en
-      def iFeature(name)
-        I18n.config.default_locale = options[:lang]
-        in_root_project_folder?
-
-        create_feature_file name, 'IOS'
-        create_steps_file name, 'IOS'
-        create_screen_file name, 'IOS'
+      
+      def initialize(*args)
+        super        
+        # Load CLI
+        @cli = HighLine.new
       end
+    end
+  end
+end
 
-      desc 'step [RESOURCE_NAME]', 'Generates an OS independent step'
-      option :lang,
-             banner: 'any of the gherkin supported languages',
-             default: :en
-      def step(name)
-        I18n.config.default_locale = options[:lang]
-        in_root_project_folder?
-        create_steps_file name
+module CS
+  module BDD
+    class Build < Thor
+      desc 'ios [PROFILE]',
+           'Build project in IOS.'
+      option  :device,
+              :desc => 'UUID to device install app.',
+              :banner => 'UUID'
+              
+      def ios(profile = nil)
+        @cli.say("Loading...") if #!in_root_project_folder?
+        
+        profile ||= answer_profile
+        
+        if !profile_exist? (profile)
+          @cli.say("Profile inválid.")
+          profile = answer_profile
+        end
+        configs = profile_configs[profile]
+        
+        command = "APP_BUNDLE_PATH='#{configs["export_path"]}/#{configs["scheme"]}.app'"
+        command += " PROJECT_DIR='#{project_folder_by_xcworkspace(configs["xcworkspace"])}'"
+        command += " DEVICET=#{options[:device]}"
+        command += " DEVICE_ENDPOINT=http://#{ip_address}:#{options[:port]}"
+        command += " bundle exec cucumber -p ios"
+        command += " -t #{options[:tags]}" if options[:tags]
+        
+        @cli.say("Running command:\n")
+        @cli.say("#{command.colorize(:blue)}\n\n")
+        
+        exec(command)
       end
-
-      desc 'aStep [RESOURCE_NAME]', 'Generates an Android dependent step'
-      option :lang,
-             banner: 'any of the gherkin supported languages',
-             default: :en
-      def aStep(name)
-        I18n.config.default_locale = options[:lang]
-        in_root_project_folder?
-        create_steps_file name, 'Android'
-      end
-
-      desc 'iStep [RESOURCE_NAME]', 'Generates an iOS dependent step'
-      option :lang,
-             banner: 'any of the gherkin supported languages',
-             default: :en
-      def iStep(name)
-        I18n.config.default_locale = options[:lang]
-        in_root_project_folder?
-        create_steps_file name, 'IOS'
-      end
-
-      desc 'screen [RESOURCE_NAME]',
-           'Generates the Android and iOS dependent screens'
-      option :lang,
-             banner: 'any of the gherkin supported languages',
-             default: :en
-      def screen(name)
-        I18n.config.default_locale = options[:lang]
-        in_root_project_folder?
-        create_screen_file name, 'Android'
-        create_screen_file name, 'IOS'
-      end
-
-      desc 'aScreen [RESOURCE_NAME]', 'Generates an Android dependent screen'
-      option :lang,
-             banner: 'any of the gherkin supported languages',
-             default: :en
-      def aScreen(name)
-        I18n.config.default_locale = options[:lang]
-        in_root_project_folder?
-        create_screen_file name, 'Android'
-      end
-
-      desc 'iScreen [RESOURCE_NAME]', 'Generates an iOS dependent screen'
-      option :lang,
-             banner: 'any of the gherkin supported languages',
-             default: :en
-      def iScreen(name)
-        I18n.config.default_locale = options[:lang]
-        in_root_project_folder?
-        create_screen_file name, 'IOS'
-      end
-
-      def self.source_root
-        File.join(File.dirname(__FILE__), '..', 'lib', 'templates')
+      
+      def initialize(*args)
+        super        
+        # Load CLI
+        @cli = HighLine.new
       end
     end
   end
@@ -134,14 +129,15 @@ module CS
       map '-v' => :version
       map '--version' => :version
 
-      default_task :help
-
       register CS::BDD::Generate, 'generate',
                'generate [GENERATOR] [RESOURCE_NAME]',
                'Generates various resources'
       register CS::BDD::Generate, 'g',
                'g [GENERATOR] [RESOURCE_NAME]',
                'Generates various resources'
+      register CS::BDD::Runner, 'runner',
+              'run [PLATFORM]',
+              'Run tests in Android or iOS'
 
       desc 'new PROJECT_NAME',
            'Generates the structure of a new project that uses '\
@@ -211,6 +207,9 @@ module CS
         ]
         I18n.backend.load_translations
         I18n.config.enforce_available_locales = true
+        
+        # Load Colorize
+        require 'colorize'
       end
     end
   end

--- a/bin/cs-bdd-helpers.rb
+++ b/bin/cs-bdd-helpers.rb
@@ -115,3 +115,7 @@ end
 def ios_project_build_exist?(project_build)
   File.exist?(project_build)
 end
+
+def uuid_get_type_target(uuid)
+  options[:device].include?("-") ? "simulator" : "device"
+end

--- a/bin/cs-bdd-helpers.rb
+++ b/bin/cs-bdd-helpers.rb
@@ -75,3 +75,43 @@ def in_root_project_folder?
 
   true
 end
+
+def profile_configs
+  build_app_path = File.join(FileUtils.pwd, 'config', "scripts", "ios", "build_app.yml")
+  YAML.load_file(build_app_path)
+end
+
+def answer_profile
+  @cli.say("\n")
+  @cli.choose do |menu|
+    menu.prompt = "\nPlease choose your profile config?  "
+    profile_configs.keys.each do |profile|
+      menu.choice(profile.to_sym) { return profile }
+    end
+  end
+end
+
+def answer_device_ios
+  @cli.say("\n")
+  devices = `instruments -s devices || exit`
+  device = @cli.choose do |menu|
+    menu.prompt = "\nPlease choose your device? "
+    devices.each_line do |line|
+      menu.choice(line.strip) if /\[(.+)\]/ =~ line
+    end
+  end
+  /\[(.+)\]/.match(device).captures.first
+end
+
+def profile_exist?(profile)
+  profile_configs.keys.include?(profile)
+end
+
+def project_folder_by_xcworkspace(xcworkspace)
+  filename = xcworkspace.split('/').last
+  xcworkspace.chomp(filename)
+end
+
+def ios_project_build_exist?(project_build)
+  File.exist?(project_build)
+end

--- a/cs-bdd.gemspec
+++ b/cs-bdd.gemspec
@@ -18,9 +18,11 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'bundler', '>=1.7'
-  spec.add_runtime_dependency 'rake', '>=10.0'
-  spec.add_runtime_dependency 'thor', '>=0.19.1'
-  spec.add_runtime_dependency 'i18n', '>=0.6.11'
-  spec.add_runtime_dependency 'gherkin', '>=2.12.2'
+  spec.add_runtime_dependency 'bundler', '~>1.7'
+  spec.add_runtime_dependency 'rake', '~>10.0'
+  spec.add_runtime_dependency 'thor', '~>0.19.1'
+  spec.add_runtime_dependency 'i18n', '~>0.6.11'
+  spec.add_runtime_dependency 'gherkin', '~>2.12.2'
+  spec.add_runtime_dependency 'highline', '~>1.7.8'
+  spec.add_runtime_dependency 'colorize', '~>0.7.7'
 end

--- a/lib/cs/bdd/version.rb
+++ b/lib/cs/bdd/version.rb
@@ -1,5 +1,5 @@
 module CS
   module BDD
-    VERSION = '0.1.7'
+    VERSION = '0.1.8'
   end
 end


### PR DESCRIPTION
Olá Pessoal,

Meu nome é Rodrigo, sou desenvolvedor da CI&T utilizo a biblioteca do CS-BDD no projeto e gostaria de contribuir com algumas coisas.

Criei um comando para rodar o calabash ios/android a partir da biblioteca do CS-BDD utilizando o Bundle, isso faz com que não temos problemas com o uso errado do Ruby, ou seja sem 'bundle exec'.

Também facilita o desenvolvedor que está entrando no projeto rodar o projeto, pois o comendo ficou bem mais simples.

cs-bdd run [PLATFORM] 
cs-bdd run ios [IP_ADDRESS] [PROFILE]
cs-bdd run android [APK]

No iOS os ganhos são ainda melhores, onde pergunta se quer fazer o build e já identifica usando o instruments quais devices estão conectados.

Qualquer duvida pode me chamar no Talk: rodrigogd@ciandt.com.

Grato.
