### PR TITLE
add translation to PT form base_steps and android_screen_base templates

### DIFF
--- a/lib/sunomono/locales/pt.yml
+++ b/lib/sunomono/locales/pt.yml
@@ -7,6 +7,29 @@ pt:
     insert_steps: "Insira os passos"
     elements: "Declare todos os elementos da tela"
     actions: "Declare todas as acoes da tela"
+    wait_1: "aguardar_progresso é um metodo da classe base, então não importa o que é"
+    wait_2: "o valor da variavel @page, porque todas as screens vão ter este metodo"
+    method_missing_1: " Se o nome do metodo começar com tocar_, executar o metodo"
+    method_missing_2: " tocar no elemento da tela usando o nome do elemento que é o"
+    method_missing_3: " nome do metodo sem o primeiro caracteres 'tocar_'"
+    starts_enter_1: " Se o metodo começar com enter_, eecutar o metodo enter usando"
+    starts_enter_2: " o nome do campo, que é o nome do metodo sem os caracteres"
+    starts_enter_3: " 'enter_ e os caracteres finais '_field"
+    termina_com_visible_1: "Se o metodo termina com _visivel?, executar o metodo visivel?"
+    termina_com_visible_2: "O nome do campo é o nome do metodo sem o final"
+    termina_com_visible_3: "com os caracteres '_visivel?"
+    termina_com_visible_4: "Faz o mesmo que o metodo acima, mas joga uma exception"
+    termina_com_visible_5: "se p campo não estiver visivel"
+    wait_for_progress: "A barra de progresso da aplicação é uma view customizada"
+    is_on_page_1: "Negação indica que queremos uma pagina que não"
+    is_on_page_2: "tenha a mensagem passada como parâmetro"
+    is_on_page_3: "Se a negação não for nil, temos que exibir um erro"
+    is_on_page_4: "se a mensagem for encontrada na view"
+    is_on_page_5: "somente exibir a execption se a negação foi nil,"
+    is_on_page_6: "senão este será o comportamento esperado"
+    select_date_1: "Tocar no campo seletor da data"
+    select_date_2: "Definindo a data"
+    select_date_3: "Clicando no botão Feito"
   steps:
     drag_until: 'que Eu (?:arrastei|arrasto) a tela para (baixo|cima|esquerda|direita) ate ver o elemento "(.*?)"'
     page_contains: "que Eu estou em uma pagina que contem '(.*?)'"
@@ -25,3 +48,29 @@ pt:
     down: 'baixo'
     left: 'esquerda'
     right: 'direita'
+  screen_base:
+    restart_app: 'reiniciar_app'
+    wait_for_progress: 'aguardar_progresso'
+    wait_for_element_does_not_exist: 'aguardar_por_elemento_nao_existe'
+    is_on_page?: 'esta_na_pagina?'
+    drag_until_element_is_visible_with_special_query: 'arraste_ate_elemento_estar_visivel_com_query_especial'
+    drag_for_specified_number_of_times: 'arraste_por_um_numero_especifico_de_vezes'
+    drag_until_element_is_visible: 'arrastar_ate_elemento_estar_visivel'
+    touch_screen_element: 'tocar_elemento_da_tela'
+    touch_element_by_index: 'tocar_elemento_pelo_index'
+    drag_to: 'arrastar_para'
+    method_missing: 'metodo_ausente'
+    start_with?: 'comeca_com?'
+    end_with?: 'termina_com?'
+    touch_: 'tocar_'
+    _visible?: '_visivel?'
+    visivel?: 'visivel?'
+    _visible!: '_visivel!'
+    field_name: 'nome_do_campo'
+    clear_text_field: "apagar_campo_texto"
+    clear_text_in: "apagar_texto"
+    select_date_on_date_picker: "selecionar_data_no_seletor_de_datas"
+  exceptions:
+    unexpected_page: "Pagina inesperada. Esta pagina não deveria"
+    unexpected_page_expected_was: "Pagina inesperada. O esperado era"
+    problem_in_touch_screen: "Problema em tocar no elemento da tela"

--- a/lib/templates/android_screen_base.tt
+++ b/lib/templates/android_screen_base.tt
@@ -16,37 +16,37 @@ class AndroidScreenBase < Calabash::ABase
     start_test_server_in_background
   end
 
-  def method_missing(method, *args)
-    if method.to_s.start_with?('touch_')
-      # If method name starts with touch_, executes the touch
-      # screen element method using the element name which is the
-      # method name without the first 'touch_' chars
-      touch_screen_element public_send(method.to_s.sub('touch_', ''))
-    elsif method.to_s.start_with?('enter_')
-      # If method starts with enter_, execute the enter method using
-      # the field name, which is the method name without the initial
-      # 'enter_' chars and appended '_field' chars
+  def <%= I18n.translate( "screen_base.method_missing" ) %> (method, *args)
+    if method.to_s.<%= I18n.translate "screen_base.start_with?" %>('<%= I18n.translate "screen_base.touch_" %>')
+      # <%= I18n.translate( "comments.method_missing_1" ) %>
+      # <%= I18n.translate( "comments.method_missing_2" ) %>
+      # <%= I18n.translate( "comments.method_missing_3" ) %>
+      <%= I18n.translate( "screen_base.touch_screen_element" ) %> public_send(method.to_s.sub('<%= I18n.translate"screen_base.touch_" %>', ''))
+    elsif method.to_s.<%= I18n.translate "screen_base.start_with?" %>('enter_')
+      # <%= I18n.translate( "comments.starts_enter_1" ) %>
+      # <%= I18n.translate( "comments.starts_enter_2" ) %>
+      # <%= I18n.translate( "comments.starts_enter_3" ) %>
       enter args[0], public_send("#{method.to_s.sub('enter_', '')}_field")
-    elsif method.to_s.end_with?('_visible?')
-      # If method ends with _visible?, executes the visible? method
-      # The field name is the method name without de ending
-      # '_visible? chars
-      visible? public_send(method.to_s.sub('_visible?', ''))
-    elsif method.to_s.end_with?('_visible!')
-      # Do the same as the method above, but throws an exception
-      # if the field is not visible
-      field_name = method.to_s.sub('_visible!', '')
+    elsif method.to_s.<%= I18n.translate "screen_base.end_with?" %>('<%= I18n.translate "screen_base._visible?" %>')
+      # <%= I18n.translate( "comments.termina_com_visible_1" ) %>
+      # <%= I18n.translate( "comments.termina_com_visible_2" ) %>
+      # <%= I18n.translate( "comments.termina_com_visible_3" ) %>
+      <%= I18n.translate( "screen_base.visible?" ) %> public_send(method.to_s.sub('<%= I18n.translate "screen_base._visible?" %>', ''))
+    elsif method.to_s.<%= I18n.translate "screen_base.end_with?" %>('<%= I18n.translate "screen_base._visible!" %>')
+      # <%= I18n.translate( "comments.termina_com_visible_4" ) %>
+      # <%= I18n.translate( "comments.termina_com_visible_5" ) %>
+      <%= I18n.translate( "screen_base.field_name" ) %> = method.to_s.sub('<%= I18n.translate "screen_base._visible!" %>', '')
                          .sub('_field', '')
                          .sub('_', ' ')
                          .capitalize
       raise ElementNotFoundError, "ID: #{field_name}" unless
-        visible? public_send(method.to_s.sub('_visible!', ''))
+        <%= I18n.translate( "screen_base._visible?" ) %> public_send(method.to_s.sub('<%= I18n.translate "screen_base._visible!" %>', ''))
     else
       super(method, args)
     end
   end
 
-  def visible?(id, query = nil)
+  def <%= I18n.translate( "screen_base._visible?" ) %>(id, query = nil)
     query = "* id:'#{id}'" if query.nil?
     begin
       wait_for(timeout: 3) { element_exists query }
@@ -58,14 +58,14 @@ class AndroidScreenBase < Calabash::ABase
 
   element(:loading_screen)      { 'insert_loading_view_id' }
 
-  # The progress bar of the application is a custom view
-  def wait_for_progress
+  # <%= I18n.translate( "comments.wait_for_progress" ) %>
+  def <%= I18n.translate( "screen_base.wait_for_progress" ) %>
     sleep(2)
-    wait_for_element_does_not_exist("* id:'#{loading_screen}'",
+    <%= I18n.translate( "screen_base.wait_for_element_does_not_exist" ) %>("* id:'#{loading_screen}'",
                                     timeout: 10)
   end
 
-  def drag_to(direction)
+  def <%= I18n.translate( "screen_base.drag_to" ) %>(direction)
     positions = [0, 0, 0, 0] # [ 'from_x', 'to_x', 'from_y', 'to_y' ]
 
     case(direction)
@@ -88,12 +88,12 @@ class AndroidScreenBase < Calabash::ABase
     sleep(1)
   end
 
-  def drag_until_element_is_visible_with_special_query(direction, element)
-    drag_until_element_is_visible direction, element,
+  def <%= I18n.translate( "screen_base.drag_until_element_is_visible_with_special_query" ) %>(direction, element)
+    <%= I18n.translate( "screen_base.drag_until_element_is_visible" ) %>, element,
                                   "* {text CONTAINS[c] '#{element}'}"
   end
 
-  def drag_until_element_is_visible(direction, element, query = nil, limit = 15)
+  def <%= I18n.translate( "screen_base.drag_until_element_is_visible" ) %>(direction, element, query = nil, limit = 15)
     i = 0
 
     element_query = ''
@@ -105,7 +105,7 @@ class AndroidScreenBase < Calabash::ABase
 
     sleep(2)
     while !element_exists(element_query) && i < limit
-      drag_to direction
+      <%= I18n.translate( "screen_base.drag_to" ) %> direction
       i += 1
     end
 
@@ -114,15 +114,15 @@ class AndroidScreenBase < Calabash::ABase
       i < limit
   end
 
-  def drag_for_specified_number_of_times(direction, times)
+  def <%= I18n.translate( "screen_base.drag_for_specified_number_of_times ") %>(direction, times)
     times.times do
-      drag_to direction
+      <%= I18n.translate( "screen_base.drag_to" ) %> direction
     end
   end
 
-  # Negation indicates that we want a page that doesn't
-  # has the message passed as parameter
-  def is_on_page?(page_text, negation = '')
+  # <%= I18n.translate( "comments.is_on_page_1" ) %>
+  # <%= I18n.translate( "comments.is_on_page_2" ) %>
+  def <%= I18n.translate( "screen_base.is_on_page?" ) %>(page_text, negation = '')
   fail 'Error! Invalid query string!' if
        page_text.to_s == ''
 
@@ -130,19 +130,19 @@ class AndroidScreenBase < Calabash::ABase
     should_have_exception = false
     begin
       wait_for(timeout: 5) { has_text? page_text }
-      # If negation is not nil, we should raise an error
-      # if this message was found on the view
+      # <%= I18n.translate( "comments.is_on_page_3" ) %>
+      # <%= I18n.translate("comments.is_on_page_4" ) %>
       should_not_have_exception = true unless negation == ''
     rescue
-      # only raise exception if negation is nil,
-      # otherwise this is the expected behaviour
+      # <%= I18n.translate( "comments.is_on_page_5" ) %>
+      # <%= I18n.translate( "comments.is_on_page_6" ) %>
       should_have_exception = true if negation == ''
     end
 
-    fail "Unexpected Page. The page should not have: '#{page_text}'" if
+    fail "<%= I18n.translate( "exceptions.unexpected_page" ) %>: '#{page_text}'" if
       should_not_have_exception
 
-    fail "Unexpected Page. Expected was: '#{page_text}'" if
+    fail "<%= I18n.translate( "exceptions.unexpected_page_expected_was" ) %>: '#{page_text}'" if
       should_have_exception
   end
 
@@ -154,33 +154,33 @@ class AndroidScreenBase < Calabash::ABase
     end
   end
 
-  def touch_screen_element(element, query = nil)
+  def <%= I18n.translate( "screen_base.touch_screen_element" ) %>(element, query = nil)
     query = "* id:'#{element}'" if query.nil?
     begin
       wait_for(timeout: 5) { element_exists(query) }
       touch(query)
     rescue => e
-      raise "Problem in touch screen element: '#{element}'\nError Message: #{e.message}"
+      raise "<%= I18n.translate( "exceptions.problem_in_touch_screen" ) %>: '#{element}'\nError Message: #{e.message}"
     end
   end
 
-  def touch_element_by_index(id, index)
+  def <%= I18n.translate( "screen_base.touch_element_by_index" ) %>(id, index)
     wait_for(timeout: 5) { element_exists("* id:'#{id}' index:#{index}") }
     touch("* id:'#{id}' index:#{index}")
   end
 
-  def clear_text_field(field)
-    clear_text_in("android.widget.EditText id:'#{field}'}")
+  def <%= I18n.translate( "screen_base.clear_text_field" ) %>(field)
+    <%= I18n.translate( "screen_base.clear_text_in" ) %>("android.widget.EditText id:'#{field}'}")
   end
 
-  def select_date_on_date_picker(date, date_picker_field_id)
-    # Touch the date picker field
+  def <%= I18n.translate( "screen_base.select_date_on_date_picker" ) %>(date, date_picker_field_id)
+    # <%= I18n.translate( "comments.select_date_1" ) %>
     touch "* id:'#{date_picker_field_id}'"
 
-    # Setting the date
+    # <%= I18n.translate( "comments.select_date_2" ) %>
     set_date 'DatePicker', date.year, date.month, date.day
 
-    # Clicking in the Done button
+    # <%= I18n.translate( "comments.select_date_2" ) %>
     touch "* id:'button1'"
   end
 end

--- a/lib/templates/base_steps.tt
+++ b/lib/templates/base_steps.tt
@@ -1,44 +1,44 @@
 ######### <%= I18n.translate( :given ).upcase %> #########
 <%= I18n.translate( :given ).capitalize %>(/^<%= I18n.translate( "steps.drag_until" ) %>$/) do |direction, element|
-  @page.drag_until_element_is_visible_with_special_query direction.to_sym, element
+  @page.<%= I18n.translate 'screen_base.drag_until_element_is_visible_with_special_query' %> direction.to_sym, element
 end
 
 <%= I18n.translate( :given ).capitalize %>(/^<%= I18n.translate( "steps.page_contains" ) %>$/) do |page_text|
-  @page.is_on_page? page_text
+  @page.<%= I18n.translate( "screen_base.is_on_page?" ) %> page_text
 end
 
 ######### <%= I18n.translate( :when ).upcase %> #########
 
 <%= I18n.translate( :when ).capitalize %>(/^<%= I18n.translate( "steps.drag_number_of_times" ) %>$/) do |direction, times|
-  @page.drag_for_specified_number_of_times(direction.to_sym, times.to_i)
+  @page.<%= I18n.translate( "screen_base.drag_for_specified_number_of_times" )%>(direction.to_sym, times.to_i)
 end
 
 <%= I18n.translate( :when ).capitalize %>(/^<%= I18n.translate( "steps.touch_element" ) %>$/) do |element|
-  @page.touch_screen_element element
+  @page.<%= I18n.translate( "screen_base.touch_screen_element" ) %> element
 end
 
 <%= I18n.translate( :when ).capitalize %>(/^<%= I18n.translate( "steps.drag_screen" ) %>$/) do |direction|
-  @page.drag_to direction.to_sym
+  @page.<%= I18n.translate( "screen_base.drag_to direction" ) %>.to_sym
 end
 
 <%= I18n.translate( :when ).capitalize %>(/^<%= I18n.translate( "steps.restart_app" ) %>$/) do
-  @page.restart_app
+  @page.<%= I18n.translate( "screen_base.restart_app" ) %>
 end
 
 ######### <%= I18n.translate( :then ).upcase %> #########
 
 <%= I18n.translate( :then ).capitalize %>(/^<%= I18n.translate "steps.wait_progress_bar" %>$/) do
-  # wait_for_progress is a method of the base class, so doesn't matter what is
-  # the value of the @page variable, because all screens will have this method
-  @page.wait_for_progress
+  # <%= I18n.translate( "comments.wait_1" ) %>
+  # <%= I18n.translate( "comments.wait_2" ) %>
+  @page.<%= I18n.translate( "screen_base.wait_for_progress" ) %>
 end
 
 <%= I18n.translate( :then ).capitalize %>(/^<%= I18n.translate "steps.should_see_page" %>$/) do |page_text|
-  @page.is_on_page? page_text
+  @page.<%= I18n.translate( "screen_base.is_on_page?" ) %> page_text
 end
 
 <%= I18n.translate( :then ).capitalize %>(/^<%= I18n.translate "steps.should_see_page_that_contains" %>$/) do |page_text|
-  @page.is_on_page? page_text
+  @page.<%= I18n.translate( "screen_base.is_on_page?" ) %> page_text
 end
 <% unless I18n.config.default_locale == :en %>
 


### PR DESCRIPTION
When I started working with this gem, I saw with some of my co-workers the need to translate the screen-base.rb files to  PT methods to give continuity to the code and other methods I write, which are usually in PT.

I wanted to start translating android_screen_base.rb witch is what I use more, because for now Im just testing for Android. Hope in the future i can contribute to translate ios_screen_base.rb too and what more is needed

This PR contains:
- Translation for base_steps template to PT (Portuguese)
- Translation for android_screen_base template to PR (Portuguese)