### PR TITLE
Add methods to Android and iOS Screen Base classes

### DIFF
--- a/lib/templates/android_screen_base.tt
+++ b/lib/templates/android_screen_base.tt
@@ -183,4 +183,25 @@ class AndroidScreenBase < Calabash::ABase
     # Clicking in the Done button
     touch "* id:'button1'"
   end
+
+
+
+  # @param [String] id The view's id
+  # @param [String] The complete view query (optional)
+  # @return [Array] return an array[String] associated with the views
+  def text_array_from(id, query_text = nil)
+    query_text = "* id:'#{id}'" if query_text.nil?
+    array_text = query(query_text, :text)
+    array_text
+  end
+
+  # @param [String] id The view's id
+  # @param [String] The complete view query (optional)
+  # @return [String] returns a string associated with a single view
+  def text_from(id, query_text = nil)
+    text_array_from(id, query_text).first
+  end
+
+
+
 end

--- a/lib/templates/android_screen_base.tt
+++ b/lib/templates/android_screen_base.tt
@@ -189,17 +189,16 @@ class AndroidScreenBase < Calabash::ABase
   # @param [String] id The view's id
   # @param [String] The complete view query (optional)
   # @return [Array] return an array[String] associated with the views
-  def text_array_from(id, query_text = nil)
-    query_text = "* id:'#{id}'" if query_text.nil?
-    array_text = query(query_text, :text)
-    array_text
+  def text_array_from(id, query = nil)
+    query = "* id:'#{id}'" if query.nil?
+    query(query, :text)
   end
 
   # @param [String] id The view's id
   # @param [String] The complete view query (optional)
   # @return [String] returns a string associated with a single view
-  def text_from(id, query_text = nil)
-    text_array_from(id, query_text).first
+  def text_from(id, query = nil)
+    text_array_from(id, query).first
   end
 
 

--- a/lib/templates/android_screen_base.tt
+++ b/lib/templates/android_screen_base.tt
@@ -184,8 +184,6 @@ class AndroidScreenBase < Calabash::ABase
     touch "* id:'button1'"
   end
 
-
-
   # @param [String] id The view's id
   # @param [String] The complete view query (optional)
   # @return [Array] return an array[String] associated with the views
@@ -200,7 +198,5 @@ class AndroidScreenBase < Calabash::ABase
   def text_from(id, query = nil)
     text_array_from(id, query).first
   end
-
-
 
 end

--- a/lib/templates/ios_screen_base.tt
+++ b/lib/templates/ios_screen_base.tt
@@ -251,7 +251,7 @@ class IOSScreenBase < Calabash::IBase
   # @param [String] query The complete view query (optional)
   # @return [Array] return an array[String] associated with the views
   def text_array_from(marked, query = nil)
-    query = "* marked:'#{marked}'" unless query.nil?
+    query = "* marked:'#{marked}'" if query.nil?
     query(query, :text)
   end
 

--- a/lib/templates/ios_screen_base.tt
+++ b/lib/templates/ios_screen_base.tt
@@ -248,19 +248,18 @@ class IOSScreenBase < Calabash::IBase
   end
 
   # @param [String] marked The view's 'marked' attribute
-  # @param [String] query_text The complete view query (optional)
+  # @param [String] query The complete view query (optional)
   # @return [Array] return an array[String] associated with the views
-  def text_array_from(marked, query_text = nil)
-    query_text = "* marked:'#{marked}'" unless query_text.nil?
-    array_text = query(query_text, :text)
-    array_text
+  def text_array_from(marked, query = nil)
+    query = "* marked:'#{marked}'" unless query.nil?
+    query(query, :text)
   end
 
   # @param [String] marked The view's 'marked' attribute
-  # @param [String] query_text The complete view query (optional)
+  # @param [String] query The complete view query (optional)
   # @return [String] returns a string associated with a single view
-  def text_from(marked, query_text = nil)
-    text_array_from(marked, query_text).first
+  def text_from(marked, query = nil)
+    text_array_from(marked, query).first
   end
 
 end

--- a/lib/templates/ios_screen_base.tt
+++ b/lib/templates/ios_screen_base.tt
@@ -246,4 +246,21 @@ class IOSScreenBase < Calabash::IBase
     # Touching the OK button to close the Picker
     touch "* marked:'OK'"
   end
+
+  # @param [String] marked The view's 'marked' attribute
+  # @param [String] query_text The complete view query (optional)
+  # @return [Array] return an array[String] associated with the views
+  def text_array_from(marked, query_text = nil)
+    query_text = "* marked:'#{marked}'" unless query_text.nil?
+    array_text = query(query_text, :text)
+    array_text
+  end
+
+  # @param [String] marked The view's 'marked' attribute
+  # @param [String] query_text The complete view query (optional)
+  # @return [String] returns a string associated with a single view
+  def text_from(marked, query_text = nil)
+    text_array_from(marked, query_text).first
+  end
+
 end


### PR DESCRIPTION
Methods added to AndroidScreenBase:
- `text_array_from(id, query_text = nil)`
- `text_from(id, query_text = nil)`

Methods added to iOSScreenBase:
- `text_array_from(marked, query_text = nil)`
- `text_from(marked, query_text = nil)`